### PR TITLE
Fixed subtitle charset converting bug which was caused by a typo.

### DIFF
--- a/js/subtitle.js
+++ b/js/subtitle.js
@@ -38,11 +38,11 @@ var SubManager = function(port)
         if(sub) {
             if(sub.isDownloaded) {
                 if(sub.data) {
-                    res.end(manager.decode(sub.data, sub.ISO639));
+                    res.end(manager.decode(sub.data, sub.iso639));
                 }
             }else {
                 sub.download(function (data) {
-                    res.end(manager.decode(data, sub.ISO639));
+                    res.end(manager.decode(data, sub.iso639));
                 });
             }
         }


### PR DESCRIPTION
Decoder function of the manager object was getting an undefined iso639 code. Therefore conversion wasn't working correctly for the languages that needs pre-defined conversions with the localization file. This fixed the issue.
